### PR TITLE
fix: pass DRY_RUN through to module scripts instead of short-circuiting

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -33,12 +33,7 @@ run_module() {
     fi
     
     info "Running module: $module_name"
-    
-    if [[ "$DRY_RUN" == true ]]; then
-        warn "DRY RUN: Would run $module_script"
-        return 0
-    fi
-    
+
     if [[ -f "$module_script" ]]; then
         if bash "$module_script"; then
             success "✓ Module completed: $module_name"
@@ -89,5 +84,6 @@ main() {
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     init_script
     parse_args "$@"
+    export DRY_RUN VERBOSE NON_INTERACTIVE
     main
 fi 


### PR DESCRIPTION
## Summary

- Removes the early return in `run_module` that prevented module scripts from ever running under `--dry-run`
- Exports `DRY_RUN`, `VERBOSE`, and `NON_INTERACTIVE` after `parse_args` so child processes inherit the correct runtime flags
- All module scripts already check `$DRY_RUN` internally (e.g. `setup-dotfiles.sh` passes `--no` to stow for a detailed conflict preview) — they just never got a chance to run

Fixes #3

## Test plan

- [ ] `./scripts/main.sh --dry-run` no longer prints only generic "Would run…" lines; each module now shows its own dry-run output
- [ ] `setup-dotfiles.sh` invokes `stow --no` and prints what would be symlinked
- [ ] `./scripts/main.sh` (without `--dry-run`) continues to work normally — no unintended changes to live behaviour
- [ ] `bash -n scripts/main.sh` passes syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)