### PR TITLE
fix: parse standalone args in setup-apps and setup-dotfiles

### DIFF
--- a/scripts/apps/setup-apps.sh
+++ b/scripts/apps/setup-apps.sh
@@ -177,5 +177,6 @@ main() {
 # Script entry point
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     init_script
+    parse_args "$@"
     main
 fi

--- a/scripts/config/setup-dotfiles.sh
+++ b/scripts/config/setup-dotfiles.sh
@@ -200,5 +200,6 @@ main() {
 # Script entry point
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     init_script
+    parse_args "$@"
     main
 fi


### PR DESCRIPTION
## Summary

- add `parse_args "$@"` to standalone entrypoint in `scripts/apps/setup-apps.sh`
- add `parse_args "$@"` to standalone entrypoint in `scripts/config/setup-dotfiles.sh`
- ensures `--dry-run`, `--verbose`, `--yes`, and `--config` are honored when running these modules directly

Closes #5

## Validation

- `bash -n scripts/apps/setup-apps.sh scripts/config/setup-dotfiles.sh`
- `./scripts/apps/setup-apps.sh --dry-run`
- `HOME=$(mktemp -d) REPO_ROOT="/Users/Fabi/.macos-bootstrap" ./scripts/config/setup-dotfiles.sh --dry-run`
