### PR TITLE
fix: guard .zshrc setup for fresh systems and Intel Macs

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -9,14 +9,20 @@ export PATH="$VOLTA_HOME/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 
 # Homebrew environment setup
-eval "$(/opt/homebrew/bin/brew shellenv)"
+if [[ -x "/opt/homebrew/bin/brew" ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x "/usr/local/bin/brew" ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
 
 # --------------------------------
 # Zsh Customization
 # --------------------------------
 
 # Oh My Posh: A prompt engine for any shell
-eval "$(oh-my-posh init zsh --config ~/.config/oh-my-posh/theme.omp.json)"
+if command -v oh-my-posh &> /dev/null; then
+  eval "$(oh-my-posh init zsh --config ~/.config/oh-my-posh/theme.omp.json)"
+fi
 
 # Antidote: A plugin manager for Zsh
 # Loads Antidote and its plugins


### PR DESCRIPTION
## Summary

- guard Homebrew shell initialization in `dotfiles/.zshrc` with existence checks
- support both Apple Silicon (`/opt/homebrew/bin/brew`) and Intel (`/usr/local/bin/brew`) Homebrew paths
- guard `oh-my-posh` initialization behind `command -v oh-my-posh`

This prevents startup errors on fresh systems before Homebrew/oh-my-posh are installed and avoids hardcoding only Apple Silicon paths.

Closes #6

## Validation

- `zsh -n dotfiles/.zshrc`
