### PR TITLE
fix: add defaults backups and clean logfile output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Bash syntax check
         run: |
-          bash -n scripts/main.sh
+          bash -n install.sh config.sh
           find scripts -type f -name '*.sh' -print0 | xargs -0 -I{} bash -n {}
 
       - name: Install ShellCheck
@@ -27,4 +27,5 @@ jobs:
 
       - name: Run ShellCheck
         run: |
+          shellcheck -x install.sh config.sh
           find scripts -type f -name '*.sh' -print0 | xargs -0 shellcheck -x

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,160 @@
-# Repository Guidelines
+# AGENTS.md
+Guidance for coding agents operating in this repository.
 
-## Project Structure & Module Organization
-- `install.sh`: One-liner bootstrap entry for fresh macOS.
-- `config.sh`: Central configuration (exports via `export_config`).
-- `Brewfile`: Homebrew formulas/casks/mas apps.
-- `scripts/`: All logic (Bash).
-  - `main.sh`: Orchestrator; calls modules and logging.
-  - `common.sh`: Logging, arg parsing, sudo keep-alive, traps.
-  - `core/`: OS updates, Xcode CLI, Homebrew.
-  - `apps/`: App install, Dock setup.
-  - `config/`: Dotfiles, SSH, macOS defaults.
+## Scope and priorities
+- This is a Bash-first macOS bootstrap project.
+- Prefer safe, idempotent changes that can be re-run.
+- Default to dry-run validation before real execution.
+- Respect repository patterns over generic shell patterns.
 
-## Build, Test, and Development Commands
-- Run full setup: `./scripts/main.sh`
-- Dry run (no changes): `./scripts/main.sh --dry-run`
-- Verbose logs: `./scripts/main.sh --verbose`
-- Module-only examples:
-  - `./scripts/core/install-homebrew.sh`
-  - `./scripts/apps/setup-apps.sh`
-- Lint Bash (if installed): `shellcheck scripts/**/*.sh`
-- Syntax check: `bash -n scripts/main.sh`
+## Repository map
+- `install.sh`: bootstrap entrypoint for fresh macOS systems.
+- `config.sh`: central feature flags and exported environment.
+- `Brewfile`: packages, casks, and Mac App Store apps.
+- `scripts/main.sh`: orchestrates module execution.
+- `scripts/common.sh`: shared helpers, traps, logging, and arg parsing.
+- `scripts/core/*.sh`: macOS updates, Xcode CLI tools, Homebrew.
+- `scripts/apps/setup-apps.sh`: brew bundle + Dock setup.
+- `scripts/config/setup-dotfiles.sh`: stow-based dotfile linking.
+- `scripts/config/configure-macos-defaults.sh`: `defaults write` settings.
+- `dotfiles/`: GNU Stow package contents for `$HOME`.
+- `.github/workflows/ci.yml`: syntax + ShellCheck checks.
 
-## Coding Style & Naming Conventions
-- Bash only; start scripts with `#!/usr/bin/env bash` and `set -euo pipefail`.
-- Use `common.sh` helpers: `info|warn|error|success`, `init_script`, `parse_args`, `ask_for_sudo`, `check_platform`, `run`, `ensure_brew_in_path`, `resolve_repo_root`.
-- File naming: verbs + scope, e.g., `install-*.sh`, `configure-*.sh`, `update-*.sh`.
-- Functions: lower_snake_case; constants `UPPER_SNAKE_CASE` with `readonly`.
-- Idempotent modules: safe to re-run; honor `DRY_RUN` and `VERBOSE`.
+## Build, lint, and test commands
+There is no compile step. Validation is syntax checks, linting, and dry-run behavior.
 
-## Testing Guidelines
-- Prefer `--dry-run` first; then run modules individually.
-- Validate syntax/lint: `bash -n`, `shellcheck` with `-x` for sourced files.
-- Logs are written to `/tmp/macos-bootstrap-*.log`; inspect for warnings.
-- Optional: add Bats tests under `tests/*.bats` for pure functions; mirror module names.
+### Primary execution
+- Full run: `./scripts/main.sh`
+- Dry run (recommended first): `./scripts/main.sh --dry-run`
+- Verbose run: `./scripts/main.sh --verbose`
+- Non-interactive run: `./scripts/main.sh --yes`
+- Custom config: `./scripts/main.sh --config custom-config.sh`
 
-## Commit & Pull Request Guidelines
-- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:` (e.g., `feat: add macOS defaults configuration script`).
-- Subject in imperative mood; body explains why and notable behavior changes.
-- PRs include: summary, rationale, key commands run, sample log snippet (redacted), and screenshots if UI-visible effects (Dock).
-- Link related issues; keep changes focused and minimal.
+### Run individual modules
+- macOS updates: `./scripts/core/update-macos.sh`
+- Xcode tools: `./scripts/core/install-xcode-tools.sh`
+- Homebrew: `./scripts/core/install-homebrew.sh`
+- Apps and Dock: `./scripts/apps/setup-apps.sh`
+- Dotfiles: `./scripts/config/setup-dotfiles.sh`
+- macOS defaults: `./scripts/config/configure-macos-defaults.sh`
 
-## Security & Configuration Tips
-- Scripts may require `sudo`; never embed secrets. Use `dotfiles/.ssh/config` and 1Password agent sockets from `config.sh`.
-- Be cautious modifying defaults and Dock—ensure settings match README and are reversible.
+Most modules support common flags via `parse_args` (`--dry-run`, `--verbose`, `--yes`, `--config`).
+
+### Syntax checks
+- Main script syntax: `bash -n scripts/main.sh`
+- All scripts syntax (CI-equivalent):
+  - `find scripts -type f -name '*.sh' -print0 | xargs -0 -I{} bash -n {}`
+
+### Linting
+- Lint all scripts (preferred):
+  - `find scripts -type f -name '*.sh' -print0 | xargs -0 shellcheck -x`
+- Lint glob form (works in many shells):
+  - `shellcheck -x scripts/**/*.sh`
+- Lint one file:
+  - `shellcheck -x scripts/config/setup-dotfiles.sh`
+
+`.shellcheckrc` sets `source-path=SCRIPTDIR`; keep sourced paths resolvable.
+
+### Single-test / targeted validation
+There is currently no committed `tests/` suite.
+
+Use one of these as the "single test" equivalent:
+- Single script syntax check:
+  - `bash -n scripts/core/install-homebrew.sh`
+- Single script lint check:
+  - `shellcheck -x scripts/core/install-homebrew.sh`
+- Single module dry-run smoke test:
+  - `./scripts/apps/setup-apps.sh --dry-run`
+
+If Bats tests are added later:
+- Run one test file: `bats tests/setup-dotfiles.bats`
+- Run one named case: `bats --filter 'backs up conflicts' tests/setup-dotfiles.bats`
+
+### Logs and diagnostics
+- Runtime logs: `/tmp/macos-bootstrap-YYYYMMDD-HHMMSS.log`
+- Find warnings/errors quickly:
+  - `grep -E '\[WARN\]|\[ERROR\]' /tmp/macos-bootstrap-*.log`
+
+## Code style guidelines
+
+### Language, headers, and strict mode
+- Bash only (`#!/usr/bin/env bash`).
+- Executable scripts should initialize with `init_script` from `common.sh`.
+- `init_script` sets `set -Eeuo pipefail` and traps; avoid ad-hoc trap logic unless intentionally standalone (`install.sh`).
+
+### Sourcing / imports
+- Compute script directory robustly:
+  - `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"`
+- Source shared helpers with absolute paths from `SCRIPT_DIR`.
+- Add ShellCheck source hints for non-obvious paths:
+  - `# shellcheck source=../config.sh`
+- Prefer `resolve_repo_root "$SCRIPT_DIR"` over fragile relative paths.
+
+### Formatting and structure
+- Follow `.editorconfig`: spaces, 2-space indentation, LF, final newline, trim trailing whitespace.
+- Keep functions small and task-focused.
+- Keep orchestration in `main()` and call it from a guarded entrypoint.
+- Use comments for non-obvious logic only.
+
+### Naming conventions
+- Files: `verb-scope.sh` (for example `install-homebrew.sh`, `setup-dotfiles.sh`).
+- Functions: `lower_snake_case`.
+- Constants and env knobs: `UPPER_SNAKE_CASE`.
+- Mark constants readonly when practical (`readonly NAME`).
+
+### Variables and types (Bash semantics)
+- Use `local` inside functions.
+- Quote expansions unless word splitting is intentional.
+- Represent booleans as strings: `true` / `false`.
+- Compare booleans explicitly: `[[ "$DRY_RUN" == true ]]`.
+- Prefer arrays for command options and invoke with `"${opts[@]}"`.
+
+### Command execution and idempotency
+- Prefer `run ...` for mutating commands that should respect `DRY_RUN`.
+- Function-level `DRY_RUN` guards are also acceptable for grouped operations.
+- Always check current state before mutating.
+- Keep scripts safe to re-run without harmful side effects.
+- Add guards for macOS assumptions (`Darwin`) and privilege assumptions (`sudo` / non-root).
+
+### Error handling and logging
+- Fail fast with strict mode.
+- Use `return 1` inside functions, and `exit 1` at script boundary when needed.
+- Use `info`, `warn`, `error`, and `success` for consistent logs.
+- Prefer actionable errors over generic failures.
+- Preserve rollback/cleanup behavior when mutating user state (see dotfiles backup logic).
+
+### External tools and portability
+- Assume macOS first.
+- Keep dependencies explicit: Homebrew, dockutil, stow, softwareupdate.
+- Before calling `brew` in modules, run `ensure_brew_in_path`.
+
+## Working rules for agentic changes
+- Prefer minimal diffs; avoid broad rewrites unless requested.
+- Do not remove `DRY_RUN`, `NON_INTERACTIVE`, trap cleanup, or safety checks.
+- Keep module scripts independently runnable where currently supported.
+- If adding a new flag, wire it through `parse_args` compatibility expectations.
+- Update docs (`README.md`, `AGENTS.md`) when behavior/commands change.
+
+## CI and PR expectations
+- CI currently runs:
+  - Bash syntax checks for all `scripts/**/*.sh`
+  - `shellcheck -x` for all `scripts/**/*.sh`
+- Before opening a PR, run at least:
+  - `bash -n scripts/main.sh`
+  - `find scripts -type f -name '*.sh' -print0 | xargs -0 shellcheck -x`
+  - `./scripts/main.sh --dry-run`
+
+Commit style follows Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`).
+
+## Security and safety notes
+- Never commit secrets (`.env`, private SSH material, machine-specific tokens).
+- Keep privilege escalation narrowly scoped.
+- Dock/defaults changes should be reversible and clearly logged.
+
+## Cursor/Copilot rules discovery
+Checked for additional agent rule files in this repo:
+- `.cursor/rules/`: not present
+- `.cursorrules`: not present
+- `.github/copilot-instructions.md`: not present
+
+If these files are added later, treat them as higher-priority instructions and merge them into this guide.

--- a/Brewfile
+++ b/Brewfile
@@ -12,6 +12,9 @@
 # - Utilities: System utilities and tools
 # - Mac App Store: Applications from the Mac App Store
 
+# Install GUI apps in /Applications for predictable Dock paths.
+cask_args appdir: "/Applications"
+
 # =============================================================================
 # DEVELOPMENT TOOLS
 # =============================================================================
@@ -33,9 +36,6 @@ brew "stow"
 
 # Oh My Posh - https://ohmyposh.dev/docs/installation/macos
 brew "oh-my-posh"
-
-# OpenAI Codex - AI coding assistant CLI
-cask "codex"
 
 # Opencode - Open source AI code assistant
 brew "opencode"
@@ -129,9 +129,6 @@ cask "zen"
 
 # Video player
 cask "iina"
-
-# Music streaming
-#cask "spotify"
 
 # =============================================================================
 # MAC APP STORE APPLICATIONS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ bash -n scripts/main.sh
 - File naming: verb + scope (`install-*.sh`, `configure-*.sh`, `setup-*.sh`, `update-*.sh`)
 - Functions: `lower_snake_case`; constants: `UPPER_SNAKE_CASE` with `readonly`
 - All modules must be idempotent; honor `DRY_RUN` and `VERBOSE` globals
-- Use `run` wrapper for commands that should respect dry-run mode
+- Prefer `run` for mutating commands that should respect dry-run mode; function-level `DRY_RUN` guards are also acceptable for grouped operations
 
 ## Commit Style
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ My personal macOS setup scripts for bootstrapping a fresh installation with my p
 - **Full Setup**: macOS updates, Xcode tools, Homebrew, applications, dotfiles, Dock, and system preferences
 - **Safe Preview**: Dry run mode and comprehensive logging
 - **Configurable**: Customizable via configuration file
+- **Resilient App Installs**: Base tooling is installed first; optional GUI and MAS apps are separate phases
 
 ## Project Structure
 
@@ -33,10 +34,24 @@ My personal macOS setup scripts for bootstrapping a fresh installation with my p
 
 See `Brewfile` for the complete list. Includes:
 
-- **Development**: Git, Volta, Cursor, Ghostty
-- **Security**: 1Password
-- **Productivity**: Slack, Chrome, Zen browser, Home Assistant
-- **Mac App Store**: Numbers, Pages, GCal
+- **Development tools**: Git, Volta, Antidote, Stow, GH CLI, Opencode, Oh My Posh, Postman
+- **Security & privacy**: 1Password, 1Password CLI
+- **Productivity**: Cursor, ChatGPT, Clockify, Mimestream, Ghostty, Docker, Google Drive, Raycast, Obsidian
+- **Communication**: Slack, WhatsApp
+- **Browsers & web**: Safari (system), Google Chrome, Zen, Finicky
+- **Smart home**: Home Assistant
+- **Media**: IINA
+- **Mac App Store (optional by default)**: Numbers, Pages, Super Agent, 1Password for Safari, GCal for Google Calendar
+
+## Application Install Phases
+
+`scripts/apps/setup-apps.sh` installs applications in three phases for reliability:
+
+1. **Base dependencies (blocking)**: Homebrew formulae/taps from `Brewfile`
+2. **Cask apps (non-blocking)**: Installed one-by-one; failures are logged and bootstrap continues
+3. **Mac App Store apps (optional, non-blocking)**: Disabled by default unless `INSTALL_MAS_APPS=true`
+
+This keeps unattended bootstrap stable even if optional app installs fail.
 
 ## Usage
 
@@ -59,6 +74,13 @@ curl -fsSL https://raw.githubusercontent.com/robocopklaus/macos-bootstrap/main/i
 ## Configuration
 
 Edit `config.sh` to customize what gets installed. Use `--config custom-config.sh` for custom configurations.
+
+Common toggles:
+
+- `INSTALL_APPLICATIONS=true|false` - enable/disable all app setup
+- `INSTALL_CASK_APPS=true|false` - enable/disable Homebrew cask phase
+- `INSTALL_MAS_APPS=true|false` - enable/disable Mac App Store installs (default: `false`)
+- `CUSTOMIZE_DOCK=true|false` - enable/disable Dock customization
 
 ### Adding Applications
 

--- a/config.sh
+++ b/config.sh
@@ -7,6 +7,8 @@ INSTALL_MACOS_UPDATES="${INSTALL_MACOS_UPDATES:-true}"
 INSTALL_XCODE_TOOLS="${INSTALL_XCODE_TOOLS:-true}"
 INSTALL_HOMEBREW="${INSTALL_HOMEBREW:-true}"
 INSTALL_APPLICATIONS="${INSTALL_APPLICATIONS:-true}"
+INSTALL_CASK_APPS="${INSTALL_CASK_APPS:-true}"
+INSTALL_MAS_APPS="${INSTALL_MAS_APPS:-false}"
 SETUP_DOTFILES="${SETUP_DOTFILES:-true}"
 MACOS_DEFAULTS_ENABLED="${MACOS_DEFAULTS_ENABLED:-false}"
 CUSTOMIZE_DOCK="${CUSTOMIZE_DOCK:-true}"
@@ -19,16 +21,18 @@ DRY_RUN_MODE="${DRY_RUN_MODE:-false}"
 load_custom_config() {
     local custom_config="$1"
     if [[ -f "$custom_config" ]]; then
-        info "Loading custom configuration from: $custom_config"
+        printf '[INFO] Loading custom configuration from: %s\n' "$custom_config"
+        # shellcheck source=/dev/null
         source "$custom_config"
     else
-        error "Custom configuration file not found: $custom_config"
+        printf '[ERROR] Custom configuration file not found: %s\n' "$custom_config" >&2
         return 1
     fi
 }
 
 export_config() {
     export INSTALL_MACOS_UPDATES INSTALL_XCODE_TOOLS INSTALL_HOMEBREW INSTALL_APPLICATIONS
+    export INSTALL_CASK_APPS INSTALL_MAS_APPS
     export SETUP_DOTFILES MACOS_DEFAULTS_ENABLED CUSTOMIZE_DOCK
     export VERBOSE_LOGGING DRY_RUN_MODE
-} 
+}

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 # macOS Bootstrap - Self-contained installer
 # This script can be downloaded and run directly on a fresh macOS installation
 # Usage: curl -fsSL https://raw.githubusercontent.com/robocopklaus/macos-bootstrap/main/install.sh | bash
+#
+# NOTE: This script intentionally duplicates a small subset of logic from
+# scripts/common.sh and scripts/core/* so it can run before the repository is
+# cloned locally. Keep behavior aligned with shared scripts when updating.
 
 REPO_URL="https://github.com/robocopklaus/macos-bootstrap.git"
 CLONE_DIR="$HOME/.macos-bootstrap"
-TEMP_DIR="/tmp/macos-bootstrap-$$"
+TEMP_DIR="$(mktemp -d -t macos-bootstrap.XXXXXX)"
 
 # Colors for output
 readonly RED='\033[0;31m'
@@ -166,4 +170,4 @@ main() {
 
 # Script entry point
 # Always run main when script is executed (either directly or piped)
-main "$@" 
+main "$@"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -42,13 +42,27 @@ log() {
     local message="$*"
     local timestamp
     timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
-    echo -e "[$timestamp] [$level] $message" | tee -a "$LOG_FILE"
+
+    local plain_line="[$timestamp] [$level] $message"
+    printf '%s\n' "$plain_line" >> "$LOG_FILE"
+
+    if [[ -t 1 ]]; then
+        local color="$NC"
+        case "$level" in
+            WARN) color="$YELLOW" ;;
+            ERROR) color="$RED" ;;
+            SUCCESS) color="$GREEN" ;;
+        esac
+        printf '%b\n' "${color}${plain_line}${NC}"
+    else
+        printf '%s\n' "$plain_line"
+    fi
 }
 
 info() { log "INFO" "$*"; }
-warn() { log "WARN" "${YELLOW}$*${NC}"; }
-error() { log "ERROR" "${RED}$*${NC}"; }
-success() { log "SUCCESS" "${GREEN}$*${NC}"; }
+warn() { log "WARN" "$*"; }
+error() { log "ERROR" "$*"; }
+success() { log "SUCCESS" "$*"; }
 
 # Helper to run commands with DRY_RUN awareness
 run() {

--- a/scripts/core/install-homebrew.sh
+++ b/scripts/core/install-homebrew.sh
@@ -8,8 +8,10 @@ source "$SCRIPT_DIR/../common.sh"
 # Install Homebrew
 install_homebrew() {
     info "Checking Homebrew installation..."
-    
-    if command -v brew >/dev/null 2>&1; then
+
+    # Bootstrap PATH first for shells where Homebrew is installed but not initialized
+    # yet (common in non-login or fresh bootstrap contexts).
+    if ensure_brew_in_path; then
         success "Homebrew is already installed"
         return 0
     fi

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -13,13 +13,6 @@ export REPO_ROOT
 LOG_FILE="${LOG_FILE:-/tmp/macos-bootstrap-$(date +%Y%m%d-%H%M%S).log}"
 export LOG_FILE
 
-# Load configuration
-if [[ -f "$SCRIPT_DIR/../config.sh" ]]; then
-    # shellcheck source=../config.sh
-    source "$SCRIPT_DIR/../config.sh"
-    export_config
-fi
-
 # Run a module script
 run_module() {
     local module_name="$1"
@@ -65,11 +58,12 @@ main() {
     ask_for_sudo
     
     # Core system setup
+    # With strict mode + ERR trap enabled, any failing module is fatal by default.
     run_module "macOS Updates" "$SCRIPT_DIR/core/update-macos.sh" "INSTALL_MACOS_UPDATES"
-    run_module "Xcode CLI Tools" "$SCRIPT_DIR/core/install-xcode-tools.sh" "INSTALL_XCODE_TOOLS" || exit 1
+    run_module "Xcode CLI Tools" "$SCRIPT_DIR/core/install-xcode-tools.sh" "INSTALL_XCODE_TOOLS"
 
     # Install tools and applications (Homebrew is critical - apps depend on it)
-    run_module "Homebrew" "$SCRIPT_DIR/core/install-homebrew.sh" "INSTALL_HOMEBREW" || exit 1
+    run_module "Homebrew" "$SCRIPT_DIR/core/install-homebrew.sh" "INSTALL_HOMEBREW"
     run_module "Applications & Dock" "$SCRIPT_DIR/apps/setup-apps.sh" "INSTALL_APPLICATIONS"
 
     # Configuration


### PR DESCRIPTION
## Summary
- back up relevant macOS defaults domains before applying preference changes to make defaults automation safer to roll back
- write plain text to log files while keeping colorized terminal output so diagnostics remain readable in editors and CI artifacts
- clarify DRY_RUN conventions and module failure behavior in agent/project guidance docs

## Testing
- `bash -n scripts/common.sh scripts/config/configure-macos-defaults.sh scripts/main.sh`
- `MACOS_DEFAULTS_ENABLED=true ./scripts/config/configure-macos-defaults.sh --dry-run`
- `./scripts/main.sh --dry-run`
- `rg "\\x1b" /tmp/macos-bootstrap-*.log` (no ANSI escapes expected)

Stacked on #37.

Closes #8
Closes #13
Closes #17
Closes #21